### PR TITLE
Prevent blank messages from being sent

### DIFF
--- a/Seaglass/Controller/MainViewRoomController.swift
+++ b/Seaglass/Controller/MainViewRoomController.swift
@@ -64,6 +64,12 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
         
         var formattedText: String
         let unformattedText = sender.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        if unformattedText == "" {
+            sender.stringValue = ""
+            sender.isEnabled = true
+            sender.becomeFirstResponder()
+            return
+        }
         let options = DownOptions(rawValue: 1 << 3)
         do {
             // TODO: Make sure this is suitably sanitised
@@ -77,13 +83,6 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
             }
         } catch {
             formattedText = unformattedText
-        }
-        
-        if formattedText == "" {
-            sender.stringValue = ""
-            sender.isEnabled = true
-            sender.becomeFirstResponder()
-            return
         }
         
         self.roomTyping = false


### PR DESCRIPTION
Note this isn't what Riot does. Riot only prevents completely blank messages from being sent while this prevents completely blank messages and messages that are just whitespace characters from being sent.