### PR TITLE
Fix NSInternalInconsistencyException crash by showing sheet on main thread

### DIFF
--- a/Seaglass/Controller/Main View/MainViewController.swift
+++ b/Seaglass/Controller/Main View/MainViewController.swift
@@ -83,10 +83,12 @@ class MainViewController: NSSplitViewController, MatrixServicesDelegate {
         
         MatrixServices.inst.session.crypto.deviceList.downloadKeys([request.userId], forceDownload: false, success: { (devicemap) in
             if MatrixServices.inst.session.crypto.deviceList.storedDevice(request.userId, deviceId: request.deviceId) != nil {
-                let sheet = self.storyboard?.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("KeyRequest")) as! MainViewKeyRequestController
-                sheet.request = request
-                self.presentViewControllerAsSheet(sheet)
-                self.keyRequests.append(sheet)
+                DispatchQueue.main.async {
+                    let sheet = self.storyboard?.instantiateController(withIdentifier: NSStoryboard.SceneIdentifier("KeyRequest")) as! MainViewKeyRequestController
+                    sheet.request = request
+                    self.presentViewControllerAsSheet(sheet)
+                    self.keyRequests.append(sheet)
+                }
             }
         }) { (error) in
         }


### PR DESCRIPTION
Fixes #98

The crash only happens on Mojave, on earlier versions it was just a warning.

Tested on Mojave 10.14.1 and High Sierra 10.13.6