### PR TITLE
Add a setting to change sidebar preview mode

### DIFF
--- a/Seaglass.xcodeproj/project.pbxproj
+++ b/Seaglass.xcodeproj/project.pbxproj
@@ -70,6 +70,7 @@
 		39F312632118F21C00A75E16 /* RoomAliasesController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39F312622118F21C00A75E16 /* RoomAliasesController.swift */; };
 		3D2E02EE2152CB330053D053 /* MenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D2E02ED2152CB330053D053 /* MenuController.swift */; };
 		3D502D80212E012F00C8D06E /* ContextImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D502D7F212E012F00C8D06E /* ContextImageView.swift */; };
+		3D7CE5A021C868A600733562 /* AppDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D7CE59F21C868A600733562 /* AppDefaults.swift */; };
 		3DD33CA621534C7B00888A32 /* AutoGrowingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DD33CA521534C7B00888A32 /* AutoGrowingTextField.swift */; };
 		A5EC29062126BAE800F37E0E /* AvatarImageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC29052126BAE800F37E0E /* AvatarImageView.swift */; };
 /* End PBXBuildFile section */
@@ -163,6 +164,7 @@
 		39F312622118F21C00A75E16 /* RoomAliasesController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoomAliasesController.swift; sourceTree = "<group>"; };
 		3D2E02ED2152CB330053D053 /* MenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MenuController.swift; sourceTree = "<group>"; };
 		3D502D7F212E012F00C8D06E /* ContextImageView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ContextImageView.swift; sourceTree = "<group>"; };
+		3D7CE59F21C868A600733562 /* AppDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDefaults.swift; sourceTree = "<group>"; };
 		3DD33CA521534C7B00888A32 /* AutoGrowingTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoGrowingTextField.swift; sourceTree = "<group>"; };
 		4980E7DED434EEC15109CB2E /* Pods_Seaglass.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Seaglass.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6D8D5FAB3C7EC4611494233F /* Pods-Seaglass.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Seaglass.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Seaglass/Pods-Seaglass.debug.xcconfig"; sourceTree = "<group>"; };
@@ -234,11 +236,11 @@
 				3943E0EE20CD9EF70061D51D /* Subclass */,
 				3943E0EC20CD9E4E0061D51D /* Controller */,
 				391BFE2720C68AD200B4EFEC /* Main.storyboard */,
+				391BFE1E20C68AD100B4EFEC /* AppDelegate.swift */,
 				391BFE2520C68AD200B4EFEC /* Assets.xcassets */,
 				391BFE2A20C68AD200B4EFEC /* Info.plist */,
 				391BFE2B20C68AD200B4EFEC /* Seaglass.entitlements */,
 				391BFE2220C68AD100B4EFEC /* Seaglass.xcdatamodeld */,
-				391BFE1E20C68AD100B4EFEC /* AppDelegate.swift */,
 				3982A6B82157B74D00303E84 /* dsa_pub.pem */,
 			);
 			path = Seaglass;
@@ -331,8 +333,9 @@
 		3943E0EC20CD9E4E0061D51D /* Controller */ = {
 			isa = PBXGroup;
 			children = (
-				3D2E02ED2152CB330053D053 /* MenuController.swift */,
+				3D7CE59F21C868A600733562 /* AppDefaults.swift */,
 				3943E0E820CC21590061D51D /* AboutViewController.swift */,
+				3D2E02ED2152CB330053D053 /* MenuController.swift */,
 				39EED1B1214FB4C200E8603B /* Segues */,
 				39A7D0A521459D6D0019AF6C /* Windows */,
 				39E5AA812126037B00BDA001 /* Popover Views */,
@@ -721,6 +724,7 @@
 				390E46F721518FD70017AA2C /* UserSettingsEncryptionController.swift in Sources */,
 				3D502D80212E012F00C8D06E /* ContextImageView.swift in Sources */,
 				3943AC6A21301B9300760967 /* RoomMessageOutgoingCoalesced.swift in Sources */,
+				3D7CE5A021C868A600733562 /* AppDefaults.swift in Sources */,
 				3931F29C213981A4001F91DC /* MessageInputField.swift in Sources */,
 				39F312632118F21C00A75E16 /* RoomAliasesController.swift in Sources */,
 				3943E0E720CB43A60061D51D /* LogoutViewController.swift in Sources */,

--- a/Seaglass/AppDelegate.swift
+++ b/Seaglass/AppDelegate.swift
@@ -36,7 +36,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
     func applicationDidFinishLaunching(_ aNotification: Notification) {
-        // Insert code here to initialize your application
+        AppDefaults.init()
     }
 
     func applicationWillTerminate(_ aNotification: Notification) {
@@ -123,4 +123,3 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
     }
 
 }
-

--- a/Seaglass/Base.lproj/Main.storyboard
+++ b/Seaglass/Base.lproj/Main.storyboard
@@ -915,11 +915,11 @@ Copyright 2017 © Avery Pierce</string>
                                         </tableView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="TzK-sC-UVB">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="TzK-sC-UVB">
                                     <rect key="frame" x="-100" y="-100" width="192" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="e9r-bE-GCB">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="e9r-bE-GCB">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1186,11 +1186,11 @@ Copyright 2017 © Avery Pierce</string>
                                     </subviews>
                                     <nil key="backgroundColor"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="7I3-iD-rRt">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="7I3-iD-rRt">
                                     <rect key="frame" x="-100" y="-100" width="237.74135208129883" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Bb4-cm-G0e">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="Bb4-cm-G0e">
                                     <rect key="frame" x="-100" y="-100" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -1806,11 +1806,11 @@ MgA3AEEARwBQAFcAXABkAHkAewB9AH8AgQCJAJAAlQCgAKMApQCnAKkArgC5AMIAygDNANYA2wDoAOwA
                                     <edgeInsets key="contentInsets" left="0.0" right="0.0" top="57" bottom="54"/>
                                 </clipView>
                                 <edgeInsets key="contentInsets" left="0.0" right="0.0" top="57" bottom="42"/>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="oEW-hF-5c8">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="oEW-hF-5c8">
                                     <rect key="frame" x="-100" y="-100" width="514" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Sj4-a2-0Zh">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="Sj4-a2-0Zh">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -2759,11 +2759,11 @@ DQ
                                     </subviews>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Pfq-00-ngx">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="YES" id="Pfq-00-ngx">
                                     <rect key="frame" x="0.0" y="-16" width="0.0" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="eeg-zi-Lby">
+                                <scroller key="verticalScroller" hidden="YES" verticalHuggingPriority="750" horizontal="NO" id="eeg-zi-Lby">
                                     <rect key="frame" x="224" y="17" width="15" height="102"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
@@ -3305,24 +3305,57 @@ DQ
             <objects>
                 <viewController title="Profile Settings" id="NNd-me-UhZ" customClass="UserSettingsProfileController" customModule="Seaglass" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" id="68S-9K-vsn">
-                        <rect key="frame" x="0.0" y="0.0" width="450" height="57"/>
+                        <rect key="frame" x="0.0" y="0.0" width="450" height="78"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kQI-hC-MuU">
-                                <rect key="frame" x="18" y="20" width="414" height="17"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Profile settings are not here yet..." id="4v5-7d-uUo">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RMb-lg-XUO">
+                                <rect key="frame" x="70" y="41" width="55" height="17"/>
+                                <autoresizingMask key="autoresizingMask"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Sidebar:" id="Qwr-CN-3aP">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vPD-XX-fxj">
+                                <rect key="frame" x="128" y="19" width="187" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="radio" title="Show room topic in sidebar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="RtC-7B-Aei">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="sidebarPreferenceChanged:" target="NNd-me-UhZ" id="4rM-yd-oce"/>
+                                    <binding destination="AhH-Yv-vXB" name="value" keyPath="values.showMostRecentMessageInSidebar" id="dmI-Ks-jW4">
+                                        <dictionary key="options">
+                                            <string key="NSValueTransformerName">NSNegateBoolean</string>
+                                        </dictionary>
+                                    </binding>
+                                </connections>
+                            </button>
+                            <button verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gPP-PR-EfE">
+                                <rect key="frame" x="128" y="41" width="252" height="18"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                <buttonCell key="cell" type="radio" title="Show most recent message in sidebar" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="0Zy-Ph-zdu">
+                                    <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                                    <font key="font" metaFont="system"/>
+                                </buttonCell>
+                                <connections>
+                                    <action selector="sidebarPreferenceChanged:" target="NNd-me-UhZ" id="JM6-aO-hnn"/>
+                                    <binding destination="AhH-Yv-vXB" name="value" keyPath="values.showMostRecentMessageInSidebar" id="Moa-4a-nDT"/>
+                                </connections>
+                            </button>
                         </subviews>
                     </view>
+                    <connections>
+                        <outlet property="showMostRecentMessageButton" destination="gPP-PR-EfE" id="1PK-Uh-7nk"/>
+                        <outlet property="showRoomTopicButton" destination="vPD-XX-fxj" id="HtX-wP-aLZ"/>
+                    </connections>
                 </viewController>
                 <customObject id="aUP-A2-iJd" userLabel="First Responder" customClass="NSResponder" sceneMemberID="firstResponder"/>
+                <userDefaultsController id="AhH-Yv-vXB"/>
             </objects>
-            <point key="canvasLocation" x="211" y="2094.5"/>
+            <point key="canvasLocation" x="211" y="2105"/>
         </scene>
         <!--Encryption Settings-->
         <scene sceneID="zdV-vn-Ha5">
@@ -3572,26 +3605,26 @@ DQ
                                 <rect key="frame" x="20" y="20" width="360" height="210"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <clipView key="contentView" ambiguous="YES" drawsBackground="NO" id="vmj-Bx-Dz5">
-                                    <rect key="frame" x="1" y="1" width="343" height="208"/>
+                                    <rect key="frame" x="1" y="1" width="358" height="208"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textView ambiguous="YES" editable="NO" importsGraphics="NO" richText="NO" verticallyResizable="YES" allowsCharacterPickerTouchBarItem="NO" allowsNonContiguousLayout="YES" textCompletion="NO" id="GB0-78-leA">
-                                            <rect key="frame" x="0.0" y="0.0" width="343" height="208"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="358" height="208"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            <size key="minSize" width="343" height="208"/>
+                                            <size key="minSize" width="358" height="208"/>
                                             <size key="maxSize" width="463" height="10000000"/>
                                             <color key="insertionPointColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                         </textView>
                                     </subviews>
                                 </clipView>
-                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="9Nb-Zt-rZm">
+                                <scroller key="horizontalScroller" hidden="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="9Nb-Zt-rZm">
                                     <rect key="frame" x="-100" y="-100" width="358" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
-                                <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="eBa-9H-egB">
-                                    <rect key="frame" x="344" y="1" width="15" height="208"/>
+                                <scroller key="verticalScroller" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="eBa-9H-egB">
+                                    <rect key="frame" x="343" y="1" width="16" height="208"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                             </scrollView>
@@ -4123,7 +4156,7 @@ Gw
         <image name="NSTouchBarTagIconTemplate" width="23" height="30"/>
         <image name="NSTouchBarUserAddTemplate" width="21" height="30"/>
         <image name="NSTouchBarUserTemplate" width="17" height="30"/>
-        <image name="NSUserGuest" width="128" height="128"/>
+        <image name="NSUserGuest" width="32" height="32"/>
     </resources>
     <inferredMetricsTieBreakers>
         <segue reference="Tfp-e2-cpe"/>

--- a/Seaglass/Controller/AppDefaults.swift
+++ b/Seaglass/Controller/AppDefaults.swift
@@ -1,0 +1,57 @@
+//
+// Seaglass, a native macOS Matrix client
+// Copyright © 2018, Neil Alexander
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+
+import Foundation
+
+final class AppDefaults {
+    
+    static let shared = AppDefaults()
+    
+    struct Key {
+        static let showMostRecentMessageInSidebar = "showMostRecentMessageInSidebar"
+    }
+    
+    @discardableResult init() {
+        let defaults: [String: Any] = [
+            Key.showMostRecentMessageInSidebar: true
+        ]
+        
+        UserDefaults.standard.register(defaults: defaults)
+    }
+    
+    var showMostRecentMessageInSidebar: Bool {
+        get {
+            return bool(for: Key.showMostRecentMessageInSidebar)
+        }
+        set {
+            setBool(for: Key.showMostRecentMessageInSidebar, newValue)
+        }
+    }
+}
+
+private extension AppDefaults {
+    
+    func bool(for key: String) -> Bool {
+        return UserDefaults.standard.bool(forKey: key)
+    }
+    
+    func setBool(for key: String, _ flag: Bool) {
+        UserDefaults.standard.set(flag, forKey: key)
+    }
+
+}

--- a/Seaglass/Controller/Main View/MainViewRoomsController.swift
+++ b/Seaglass/Controller/Main View/MainViewRoomsController.swift
@@ -144,10 +144,8 @@ class MainViewRoomsController: NSViewController, MatrixRoomsDelegate, NSTableVie
             cell?.RoomListEntryTopic.stringValue = "Room invite"
             cell?.RoomListEntryUnread.isHidden = false
         } else {
-            let topicMode = "lastMessagePreview" // TODO: set this via user preferences
-            
-            switch topicMode {
-                case "metadata":
+            switch AppDefaults.shared.showMostRecentMessageInSidebar {
+                case false:
                     var memberString: String = ""
                     var topicString: String = "No topic set"
                     
@@ -164,7 +162,7 @@ class MainViewRoomsController: NSViewController, MatrixRoomsDelegate, NSTableVie
                     
                     cell?.RoomListEntryTopic.stringValue = "\(memberString)\n\(topicString)"
                     break
-                default: // lastMessagePreview
+                case true:
                     let lastMessagePreview: String = state.room.summary.lastMessageEvent?.content["body"] as? String ?? ""
                     cell?.RoomListEntryTopic.cell?.truncatesLastVisibleLine = true
                     cell?.RoomListEntryTopic.stringValue = lastMessagePreview

--- a/Seaglass/Controller/MenuController.swift
+++ b/Seaglass/Controller/MenuController.swift
@@ -19,6 +19,7 @@
 import Cocoa
 
 class MenuController: NSMenu {
+    
 	@IBAction func focusOnRoomSearchField(_ sender: NSMenuItem) {
 		sender.target = self
 
@@ -33,9 +34,9 @@ class MenuController: NSMenu {
 			searchField.currentEditor()?.selectedRange = NSMakeRange(lengthOfInput, 0)
 		}
 	}
+    
     @IBAction func inviteButtonClicked(_ sender: NSMenuItem) {
-        
         MatrixServices.inst.mainController?.channelDelegate?.uiRoomStartInvite()
-        
     }
+    
 }

--- a/Seaglass/Controller/User Settings Views/UserSettingsProfileController.swift
+++ b/Seaglass/Controller/User Settings Views/UserSettingsProfileController.swift
@@ -19,11 +19,18 @@
 import Cocoa
 
 class UserSettingsProfileController: UserSettingsTabController {
-
+    
+    @IBOutlet weak var showMostRecentMessageButton: NSButton!
+    @IBOutlet weak var showRoomTopicButton: NSButton!
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        resizeToSize = NSSize(width: 450, height: 57)
+        resizeToSize = NSSize(width: 450, height: 75)
     }
     
+    @IBAction func sidebarPreferenceChanged(_ sender: NSButton) {
+        // the buttons need to be set to the same action so they act as a group
+    }
+
 }


### PR DESCRIPTION
Expands on #101 with a setting that allows you to switch between the two modes. This PR works great except that it doesn't immediately refresh the sidebar. You have to close and reopen the main window before the change takes effect but at least this is a start.

I filled #106 to track future improvements to this mode.

-----

Just for my future reference 
The commented code does the same thing as the Cocoa Bindings:
![screen shot 2018-12-17 at 9 42 12 pm](https://user-images.githubusercontent.com/5855073/50132898-e8ec0f80-024e-11e9-8bac-2863606a6952.png)