### PR TITLE
Adds  ⌃⌘↑ and ⌃⌘↓ for scrolling a room's history

### DIFF
--- a/Seaglass/Base.lproj/Main.storyboard
+++ b/Seaglass/Base.lproj/Main.storyboard
@@ -707,6 +707,25 @@ Copyright 2017 © Avery Pierce</string>
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Navigate" id="DFe-kW-kSJ">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Navigate" id="WPh-c6-hC8">
+                                    <items>
+                                        <menuItem title="Jump to Oldest" keyEquivalent="" id="ys5-AV-Cjm">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES"/>
+                                            <connections>
+                                                <action selector="gotoOldestLoaded:" target="AYu-sK-qS6" id="pcU-Q8-fAG"/>
+                                            </connections>
+                                        </menuItem>
+                                        <menuItem title="Jump to Newest" keyEquivalent="" id="86g-yf-QiX">
+                                            <modifierMask key="keyEquivalentModifierMask" control="YES" option="YES"/>
+                                            <connections>
+                                                <action selector="gotoNewest:" target="AYu-sK-qS6" id="dMM-h8-aax"/>
+                                            </connections>
+                                        </menuItem>
+                                    </items>
+                                </menu>
+                            </menuItem>
                             <menuItem title="Window" id="aUF-d1-5bR">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Window" systemMenu="window" id="Td7-aD-5lo">

--- a/Seaglass/Controller/MenuController.swift
+++ b/Seaglass/Controller/MenuController.swift
@@ -39,4 +39,20 @@ class MenuController: NSMenu {
         MatrixServices.inst.mainController?.channelDelegate?.uiRoomStartInvite()
     }
     
+    @IBAction func gotoOldestLoaded(_ sender: NSMenuItem) {
+        let mainWindow = NSApplication.shared.mainWindow
+        let splitViewController = mainWindow?.contentViewController as? NSSplitViewController
+        let mainRoomViewController = splitViewController?.splitViewItems.last?.viewController as? MainViewRoomController
+        
+        mainRoomViewController?.RoomMessageTableView.scrollToBeginningOfDocument(self)
+    }
+    
+    @IBAction func gotoNewest(_ sender: NSMenuItem) {
+        let mainWindow = NSApplication.shared.mainWindow
+        let splitViewController = mainWindow?.contentViewController as? NSSplitViewController
+        let mainRoomViewController = splitViewController?.splitViewItems.last?.viewController as? MainViewRoomController
+        
+        mainRoomViewController?.RoomMessageTableView.scrollToEndOfDocument(self)
+    }	
+    
 }


### PR DESCRIPTION
Per #82 I added a shortcut to scroll to the newest message in a room and the oldest (cached) message.

One caveat: scrolling to the oldest doesn't seem to refresh whatever tracks user scrolling, so no new messages are pulled. You have to scroll down and then back up for Seaglass to start loading more history. I'm not sure how to fix that (this is my first time writing any Swift... so I don't have a great grasp of the project yet) so if you have any guidance, I'm happy to make changes!