### PR TITLE
Automatically restore window position and size

### DIFF
--- a/Seaglass/AppDelegate.swift
+++ b/Seaglass/AppDelegate.swift
@@ -51,6 +51,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, NSMenuDelegate {
         
         if let window = controller.window {
             window.makeKeyAndOrderFront(self)
+            window.setFrameAutosaveName(NSWindow.FrameAutosaveName("seaglass-main"))
             return true
         }
         


### PR DESCRIPTION
I noticed that seaglass doesn't retain window size and position. Setting the autosave name allows to be automatically restored from user prefs.