### PR TITLE
Update SwiftMatrixSDK to v0.11.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     macos:
-      xcode: "10.2.1"
+      xcode: "11.3.1"
       # https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions
     working_directory: ~/seaglass
     shell: /bin/bash --login -o pipefail

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ inhibit_all_warnings!
 target 'Seaglass' do
   use_frameworks!
 
-  pod 'SwiftMatrixSDK', '0.10.12'
+  pod 'SwiftMatrixSDK', :git => 'https://github.com/MattHardcastle/matrix-ios-sdk.git', :commit => '0a373c1cfbe10246218b72dc843d1d0d33807ab6'
   pod 'Down'
   pod 'TSMarkdownParser'
   pod 'Sparkle'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -13,54 +13,64 @@ PODS:
   - AFNetworking/Security (3.2.1)
   - AFNetworking/Serialization (3.2.1)
   - Down (0.5.2)
-  - GZIP (1.2.2)
+  - GZIP (1.2.3)
   - LetsMove (1.24)
-  - OLMKit (2.2.2):
-    - OLMKit/olmc (= 2.2.2)
-    - OLMKit/olmcpp (= 2.2.2)
-  - OLMKit/olmc (2.2.2)
-  - OLMKit/olmcpp (2.2.2)
-  - Realm (3.6.0):
-    - Realm/Headers (= 3.6.0)
-  - Realm/Headers (3.6.0)
+  - OLMKit (3.0.0):
+    - OLMKit/olmc (= 3.0.0)
+    - OLMKit/olmcpp (= 3.0.0)
+  - OLMKit/olmc (3.0.0)
+  - OLMKit/olmcpp (3.0.0)
+  - Realm (3.11.2):
+    - Realm/Headers (= 3.11.2)
+  - Realm/Headers (3.11.2)
   - Sparkle (1.20.0)
-  - SwiftMatrixSDK (0.10.12):
+  - SwiftMatrixSDK (0.11.6):
     - AFNetworking (~> 3.2.0)
-    - GZIP (~> 1.2.1)
-    - OLMKit (~> 2.2.2)
-    - Realm (~> 3.6.0)
+    - GZIP (~> 1.2.2)
+    - OLMKit (~> 3.0.0)
+    - Realm (~> 3.11.1)
   - TSMarkdownParser (2.1.5)
 
 DEPENDENCIES:
   - Down
   - LetsMove
   - Sparkle
-  - SwiftMatrixSDK (= 0.10.12)
+  - SwiftMatrixSDK (from `https://github.com/MattHardcastle/matrix-ios-sdk.git`, commit `0a373c1cfbe10246218b72dc843d1d0d33807ab6`)
   - TSMarkdownParser
 
 SPEC REPOS:
-  https://github.com/cocoapods/specs.git:
-    - AFNetworking
+  https://github.com/CocoaPods/Specs.git:
     - Down
-    - GZIP
     - LetsMove
+    - Sparkle
+    - TSMarkdownParser
+  trunk:
+    - AFNetworking
+    - GZIP
     - OLMKit
     - Realm
-    - Sparkle
-    - SwiftMatrixSDK
-    - TSMarkdownParser
+
+EXTERNAL SOURCES:
+  SwiftMatrixSDK:
+    :commit: 0a373c1cfbe10246218b72dc843d1d0d33807ab6
+    :git: https://github.com/MattHardcastle/matrix-ios-sdk.git
+
+CHECKOUT OPTIONS:
+  SwiftMatrixSDK:
+    :commit: 0a373c1cfbe10246218b72dc843d1d0d33807ab6
+    :git: https://github.com/MattHardcastle/matrix-ios-sdk.git
 
 SPEC CHECKSUMS:
   AFNetworking: b6f891fdfaed196b46c7a83cf209e09697b94057
   Down: 587371ad58002b06023d9c602519216862c3acbc
-  GZIP: 12374d285e3b5d46cfcd480700fcfc7e16caf4f1
+  GZIP: af5c90ef903776a7e9afe6ebebd794a84a2929d4
   LetsMove: fefe56bc7bc7fb7d37049e28a14f297961229fc5
-  OLMKit: b9d8c0ffee9ea8c45bc0aaa9afb47f93fba7efbd
-  Realm: 08b464b462d4f31bbd4ba5f5a1c8722ef0a700b7
+  OLMKit: 88eda69110489f817d59bcb4353b7c247570aa4f
+  Realm: 864477d028db77f7c5a0cba64a4892ad53db128a
   Sparkle: 48999e7ee032f05ca05e28451eadf4af8ede6b44
-  SwiftMatrixSDK: 793d7505afe6cb8aa563c2c4c94613ef279bca87
+  SwiftMatrixSDK: 3b8454c837785cb66e4325051f194d79dec889d2
   TSMarkdownParser: 3224ea196ecc7148fa7e03bc438f9390d4edfb6d
 
-PODFILE CHECKSUM: 3d7addb7b20fc302245d8951a9721bc1542434b1
+PODFILE CHECKSUM: 6223d3a3a5a2c1c9cc5e217d7c0e5f881a773d6b
 
-COCOAPODS: 1.7.1
+COCOAPODS: 1.9.1

--- a/Seaglass.xcodeproj/project.pbxproj
+++ b/Seaglass.xcodeproj/project.pbxproj
@@ -634,9 +634,11 @@
 			files = (
 			);
 			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Seaglass/Pods-Seaglass-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Seaglass/Pods-Seaglass-frameworks-${CONFIGURATION}-output-files.xcfilelist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Seaglass/Controller/Embedded Views/MemberListController.swift
+++ b/Seaglass/Controller/Embedded Views/MemberListController.swift
@@ -32,16 +32,20 @@ class MemberListController: NSViewController, NSTableViewDelegate, NSTableViewDa
         if roomId == "" {
             return
         }
-        
-        for member in MatrixServices.inst.session.room(withRoomId: roomId).state.members {
-            membersCacheController.insert(MembersCacheEntry(member), atArrangedObjectIndex: 0)
-        }
-        
-        let membercount = (membersCacheController.arrangedObjects as! [MXRoomMember]).count
-        
-        MemberSearch.placeholderString = "Search \(membercount) member"
-        if membercount != 1 {
-            MemberSearch.placeholderString?.append(contentsOf: "s")
+
+        if let room = MatrixServices.inst.session.room(withRoomId: roomId) {
+            room.state { state in
+                for member in state!.members.members {
+                    self.membersCacheController.insert(MembersCacheEntry(member, state: state!), atArrangedObjectIndex: 0)
+                }
+
+                let membercount = (self.membersCacheController.arrangedObjects as! [MXRoomMember]).count
+
+                self.MemberSearch.placeholderString = "Search \(membercount) member"
+                if membercount != 1 {
+                    self.MemberSearch.placeholderString?.append(contentsOf: "s")
+                }
+            }
         }
     }
     
@@ -56,8 +60,8 @@ class MemberListController: NSViewController, NSTableViewDelegate, NSTableViewDa
         let room = MatrixServices.inst.session.room(withRoomId: roomId)
         let member: MembersCacheEntry = (membersCacheController.arrangedObjects as! [MembersCacheEntry])[row]
         var powerlevel = 0
-        if room?.state.powerLevels != nil {
-            powerlevel = room?.state.powerLevels.powerLevelOfUser(withUserID: member.userId) ?? 0
+        if member.state.powerLevels != nil {
+            powerlevel = member.state.powerLevels.powerLevelOfUser(withUserID: member.userId) ?? 0
         }
         
         let cell = tableView.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "MemberListEntry"), owner: self) as? MemberListEntry

--- a/Seaglass/Controller/Main View/MainViewEncryptionController.swift
+++ b/Seaglass/Controller/Main View/MainViewEncryptionController.swift
@@ -35,8 +35,10 @@ class MainViewEncryptionController: NSViewController {
         ConfirmSpinner.alphaValue = 0
         
         if let room = MatrixServices.inst.session.room(withRoomId: roomId) {
-            EnableEncryptionCheckbox.state = room.state.isEncrypted ? .on : .off
-            EnableEncryptionCheckbox.isEnabled = EnableEncryptionCheckbox.state == .off
+            room.state { state in
+                self.EnableEncryptionCheckbox.state = state!.isEncrypted ? .on : .off
+                self.EnableEncryptionCheckbox.isEnabled = self.EnableEncryptionCheckbox.state == .off
+            }
         } else {
             EnableEncryptionCheckbox.isEnabled = false
         }

--- a/Seaglass/Controller/Main View/MainViewRoomController.swift
+++ b/Seaglass/Controller/Main View/MainViewRoomController.swift
@@ -40,7 +40,20 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
     
     weak public var mainController: MainViewController?
     
-    var roomId: String = ""
+    var roomId: String = "" {
+        didSet {
+            room = MatrixServices.inst.session.room(withRoomId: roomId)
+        }
+    }
+    var room: MXRoom? {
+        didSet {
+            room?.state { state in
+                self.roomState = state
+            }
+
+        }
+    }
+    var roomState: MXRoomState?
     
     var roomIsTyping: Bool = false
     var roomIsPaginating: Bool = false
@@ -162,11 +175,15 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
                             MatrixServices.inst.roomCaches[self.roomId]!.replace(returnedEvent!, at: index)
                         }
                     }
-                    self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: MatrixServices.inst.session.room(withRoomId: self.roomId).state)
+                    room.state {
+                        self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: $0!)
+                    }
                 }
                 MatrixServices.inst.roomCaches[roomId]!.append(returnedEvent!)
                 localReturnedEvent = returnedEvent?.eventId ?? nil
-                matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: MatrixServices.inst.session.room(withRoomId: roomId).state)
+                room.state {
+                    self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: $0!)
+                }
             }
         } else {
             var localReturnedEvent: String? = nil
@@ -177,11 +194,15 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
                             MatrixServices.inst.roomCaches[self.roomId]!.replace(returnedEvent!, at: index)
                         }
                     }
-                    self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: MatrixServices.inst.session.room(withRoomId: self.roomId).state)
+                    room.state {
+                        self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: $0!)
+                    }
                 }
                 MatrixServices.inst.roomCaches[roomId]!.append(returnedEvent!)
                 localReturnedEvent = returnedEvent?.eventId ?? nil
-                matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: MatrixServices.inst.session.room(withRoomId: roomId).state)
+                room.state {
+                    self.matrixDidRoomMessage(event: returnedEvent!, direction: .forwards, roomState: $0!)
+                }
             }
         }
         sender.stringValue = ""
@@ -209,14 +230,18 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
         if let room = MatrixServices.inst.session.room(withRoomId: roomId) {
             let direction: MXTimelineDirection = RoomMessageClipView.bounds.minY < 0 ? .backwards : .forwards
             guard direction == .backwards else { return }
-            if room.liveTimeline.canPaginate(direction) {
-                roomIsPaginating = true
-                room.liveTimeline.paginate(10, direction: direction, onlyFromStore: false) { (response) in
-                    if response.isFailure {
-                        print("Failed to paginate: \(response.error!.localizedDescription)")
-                        return
+            room.liveTimeline { liveTimeline in
+                guard let liveTimeline = liveTimeline else { fatalError() }
+
+                if liveTimeline.canPaginate(direction) {
+                    self.roomIsPaginating = true
+                    liveTimeline.paginate(10, direction: direction, onlyFromStore: false) { (response) in
+                        if response.isFailure {
+                            print("Failed to paginate: \(response.error!.localizedDescription)")
+                            return
+                        }
+                        self.roomIsPaginating = false
                     }
-                    self.roomIsPaginating = false
                 }
             }
         }
@@ -405,10 +430,14 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
             } else {
                 if cache.filteredContent.count == 0 {
                     if let room = MatrixServices.inst.session.room(withRoomId: cacheEntry.roomId) {
-                        room.liveTimeline.resetPagination()
-                        if room.liveTimeline.canPaginate(.backwards) {
-                            room.liveTimeline.paginate(50, direction: .backwards, onlyFromStore: false) { _ in
-                                roomDidPaginate()
+                        room.liveTimeline { liveTimeline in
+                            guard let liveTimeline = liveTimeline else { fatalError() }
+
+                            liveTimeline.resetPagination()
+                            if liveTimeline.canPaginate(.backwards) {
+                                liveTimeline.paginate(50, direction: .backwards, onlyFromStore: false) { _ in
+                                    roomDidPaginate()
+                                }
                             }
                         }
                     }
@@ -553,7 +582,7 @@ class MainViewRoomController: NSViewController, MatrixRoomDelegate, NSTableViewD
         }
         var actions: [NSTableViewRowAction] = []
         if edge == .trailing {
-            if room.state.powerLevels.redact <= room.state.powerLevels.powerLevelOfUser(withUserID: MatrixServices.inst.session.myUser.userId) {
+            if roomState!.powerLevels.redact <= roomState!.powerLevels.powerLevelOfUser(withUserID: MatrixServices.inst.session.myUser.userId) {
                 actions.append(NSTableViewRowAction(style: .destructive, title: "Redact", handler: { (action, row) in
                     let event = MatrixServices.inst.roomCaches[self.roomId]!.filteredContent[row]
                     if let index = MatrixServices.inst.roomCaches[self.roomId]!.unfilteredContent.firstIndex(where: { $0.eventId == event.eventId }) {

--- a/Seaglass/Controller/Main View/MainViewRoomsController.swift
+++ b/Seaglass/Controller/Main View/MainViewRoomsController.swift
@@ -57,7 +57,9 @@ class MainViewRoomsController: NSViewController, MatrixRoomsDelegate, NSTableVie
         let rooms = roomsCacheController.arrangedObjects as! [RoomsCacheEntry]
         let isFirst = rooms.count == 0
         if !matrixIsRoomKnown(room) {
-            roomsCacheController.insert((RoomsCacheEntry(room)), atArrangedObjectIndex: 0)
+            room.state {
+                self.roomsCacheController.insert((RoomsCacheEntry(room: room, state: $0!)), atArrangedObjectIndex: 0)
+            }
         }
         roomsCacheController.rearrangeObjects()
         MatrixServices.inst.subscribeToRoom(roomId: room.roomId)

--- a/Seaglass/Controller/Room Settings Views/RoomAliasesController.swift
+++ b/Seaglass/Controller/Room Settings Views/RoomAliasesController.swift
@@ -47,24 +47,25 @@ class RoomAliasesController: NSViewController, NSTableViewDelegate, NSTableViewD
             }
             
             let suffix = MatrixServices.inst.client.homeserverSuffix ?? ":matrix.org"
-            let aliases = room!.state.aliases
-            if aliases == nil {
-                return
+
+            room!.state { state in
+                guard let state = state else { fatalError() }
+                guard let aliases = state.aliases else { return }
+                guard aliases.count > 0 else { return }
+
+                for alias in aliases {
+                    let cell = self.AliasTable.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "RoomAliasEntry"), owner: self) as? RoomAliasEntry
+                    cell?.parent = self
+                    cell?.RoomAliasName.stringValue = alias
+                    cell?.RoomAliasName.placeholderString = "#youralias\(suffix)"
+                    cell?.RoomAliasPrimary.isEnabled = MatrixServices.inst.userHasPower(inRoomId: room!.roomId, forEvent: "m.room.canonical_alias", withRoomState: state)
+                    cell?.RoomAliasPrimary.state = state.canonicalAlias == alias ? .on : .off
+                    cell?.RoomAliasName.isEnabled = alias.hasSuffix(suffix)
+                    cell?.RoomAliasDelete.isEnabled = alias.hasSuffix(suffix)
+                    self.roomAliases.append(cell!)
+                }
             }
-            if aliases!.count == 0 {
-                return
-            }
-            for alias in aliases! {
-                let cell = AliasTable.makeView(withIdentifier: NSUserInterfaceItemIdentifier(rawValue: "RoomAliasEntry"), owner: self) as? RoomAliasEntry
-                cell?.parent = self
-                cell?.RoomAliasName.stringValue = alias
-                cell?.RoomAliasName.placeholderString = "#youralias\(suffix)"
-                cell?.RoomAliasPrimary.isEnabled = MatrixServices.inst.userHasPower(inRoomId: room!.roomId, forEvent: "m.room.canonical_alias")
-                cell?.RoomAliasPrimary.state = room!.state.canonicalAlias == alias ? .on : .off
-                cell?.RoomAliasName.isEnabled = alias.hasSuffix(suffix)
-                cell?.RoomAliasDelete.isEnabled = alias.hasSuffix(suffix)
-                roomAliases.append(cell!)
-            }
+
         } else {
             let alert = NSAlert()
             alert.messageText = "Failed to open room settings"
@@ -127,81 +128,87 @@ class RoomAliasesController: NSViewController, NSTableViewDelegate, NSTableViewD
         let group = DispatchGroup()
         let room = MatrixServices.inst.session.room(withRoomId: roomId)
         let suffix = MatrixServices.inst.client.homeserverSuffix ?? ":matrix.org"
-        let aliases = room!.state.aliases != nil ? room!.state.aliases : []
-        
-        var uiCanonicalAlias: String = ""
-        var uiAliases: [String] = []
-        
-        for uiAlias in roomAliases {
-            uiAliases.append(uiAlias.RoomAliasName.stringValue)
-            if uiAlias.RoomAliasPrimary.state == .on {
-                uiCanonicalAlias = uiAlias.RoomAliasName.stringValue
-            }
-        }
-        
-        for uiAlias in uiAliases {
-            if !uiAlias.hasSuffix(suffix) {
-                continue
-            }
-            if !aliases!.contains(uiAlias) {
-                group.enter()
-                room?.addAlias(uiAlias, completion: { (response) in
-                    if response.isFailure {
-                        let alert = NSAlert()
-                        alert.messageText = "Failed to add alias \(uiAlias)"
-                        alert.informativeText = response.error!.localizedDescription
-                        alert.alertStyle = .warning
-                        alert.addButton(withTitle: "OK")
-                        alert.runModal()
-                    }
-                    group.leave()
-                })
-            }
-        }
-        
-        for alias in aliases! {
-            if !alias.hasSuffix(suffix) {
-                continue
-            }
-            if !uiAliases.contains(alias) {
-                group.enter()
-                room?.removeAlias(alias, completion: { (response) in
-                    if response.isFailure {
-                        let alert = NSAlert()
-                        alert.messageText = "Failed to remove alias \(alias)"
-                        alert.informativeText = response.error!.localizedDescription
-                        alert.alertStyle = .warning
-                        alert.addButton(withTitle: "OK")
-                        alert.runModal()
-                    }
-                    group.leave()
-                })
-            }
-        }
-        
-        if uiCanonicalAlias != room?.state.canonicalAlias {
-            group.enter()
-            room?.setCanonicalAlias(uiCanonicalAlias, completion: { (response) in
-                if response.isFailure {
-                    let alert = NSAlert()
-                    alert.messageText = "Failed to set primary alias to \(uiCanonicalAlias)"
-                    alert.informativeText = response.error!.localizedDescription
-                    alert.alertStyle = .warning
-                    alert.addButton(withTitle: "OK")
-                    alert.runModal()
+
+        room!.state { state in
+            guard let state = state else { fatalError() }
+
+            let aliases = state.aliases != nil ? state.aliases : []
+
+            var uiCanonicalAlias: String = ""
+            var uiAliases: [String] = []
+
+            for uiAlias in self.roomAliases {
+                uiAliases.append(uiAlias.RoomAliasName.stringValue)
+                if uiAlias.RoomAliasPrimary.state == .on {
+                    uiCanonicalAlias = uiAlias.RoomAliasName.stringValue
                 }
-                group.leave()
+            }
+
+            for uiAlias in uiAliases {
+                if !uiAlias.hasSuffix(suffix) {
+                    continue
+                }
+                if !aliases!.contains(uiAlias) {
+                    group.enter()
+                    room?.addAlias(uiAlias, completion: { (response) in
+                        if response.isFailure {
+                            let alert = NSAlert()
+                            alert.messageText = "Failed to add alias \(uiAlias)"
+                            alert.informativeText = response.error!.localizedDescription
+                            alert.alertStyle = .warning
+                            alert.addButton(withTitle: "OK")
+                            alert.runModal()
+                        }
+                        group.leave()
+                    })
+                }
+            }
+
+            for alias in aliases! {
+                if !alias.hasSuffix(suffix) {
+                    continue
+                }
+                if !uiAliases.contains(alias) {
+                    group.enter()
+                    room?.removeAlias(alias, completion: { (response) in
+                        if response.isFailure {
+                            let alert = NSAlert()
+                            alert.messageText = "Failed to remove alias \(alias)"
+                            alert.informativeText = response.error!.localizedDescription
+                            alert.alertStyle = .warning
+                            alert.addButton(withTitle: "OK")
+                            alert.runModal()
+                        }
+                        group.leave()
+                    })
+                }
+            }
+
+            if uiCanonicalAlias != state.canonicalAlias {
+                group.enter()
+                room?.setCanonicalAlias(uiCanonicalAlias, completion: { (response) in
+                    if response.isFailure {
+                        let alert = NSAlert()
+                        alert.messageText = "Failed to set primary alias to \(uiCanonicalAlias)"
+                        alert.informativeText = response.error!.localizedDescription
+                        alert.alertStyle = .warning
+                        alert.addButton(withTitle: "OK")
+                        alert.runModal()
+                    }
+                    group.leave()
+                })
+            }
+
+            group.notify(queue: .main, execute: {
+                self.StatusSpinner.isHidden = true
+                self.StatusSpinner.stopAnimation(self)
+                for button in [ self.AliasSave, self.AliasCancel, self.AliasAdd ] {
+                    button!.isEnabled = true
+                }
+                sender.window?.contentViewController?.dismiss(sender)
             })
         }
-        
-        group.notify(queue: .main, execute: {
-            self.StatusSpinner.isHidden = true
-            self.StatusSpinner.stopAnimation(self)
-            for button in [ self.AliasSave, self.AliasCancel, self.AliasAdd ] {
-                button!.isEnabled = true
-            }
-            sender.window?.contentViewController?.dismiss(sender)
-        })
+
     }
     
 }

--- a/Seaglass/Controller/Room Settings Views/RoomPowerLevelsController.swift
+++ b/Seaglass/Controller/Room Settings Views/RoomPowerLevelsController.swift
@@ -72,79 +72,84 @@ class RoomPowerLevelsController: NSViewController {
         
         if roomId != "" {
             guard let room = MatrixServices.inst.session.room(withRoomId: roomId) else { return }
-            guard let powerLevels = room.state.powerLevels else { return }
-            
-            initialPowerLevelDefault = powerLevels.usersDefault
-            initialPowerLevelSendMessage = powerLevels.eventsDefault
-            initialPowerLevelInvite = powerLevels.invite
-            initialPowerLevelKick = powerLevels.kick
-            initialPowerLevelBan = powerLevels.ban
-            initialPowerLevelRedactOther = powerLevels.redact
-            // initialPowerLevelNotifyAll = powerLevels. ?? 50
-            // initialPowerLevelChangeJoinRule = powerLevels. ?? 100
 
-            initialPowerLevelChangeName = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.name"] as! Int? {
-                    return powerLevel
+            room.state { state in
+                guard let state = state else { fatalError() }
+
+                guard let powerLevels = state.powerLevels else { return }
+
+                self.initialPowerLevelDefault = powerLevels.usersDefault
+                self.initialPowerLevelSendMessage = powerLevels.eventsDefault
+                self.initialPowerLevelInvite = powerLevels.invite
+                self.initialPowerLevelKick = powerLevels.kick
+                self.initialPowerLevelBan = powerLevels.ban
+                self.initialPowerLevelRedactOther = powerLevels.redact
+                // initialPowerLevelNotifyAll = powerLevels. ?? 50
+                // initialPowerLevelChangeJoinRule = powerLevels. ?? 100
+
+                self.initialPowerLevelChangeName = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.name"] as! Int? {
+                        return powerLevel
+                    }
+                    return powerLevels.stateDefault
+                }()
+                self.initialPowerLevelChangeAvatar = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.avatar"] as! Int? {
+                        return powerLevel
+                    }
+                    return powerLevels.stateDefault
+                }()
+                self.initialPowerLevelChangeCanonicalAlias = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.canonical_alias"] as! Int? {
+                        return powerLevel
+                    }
+                    return powerLevels.stateDefault
+                }()
+                self.initialPowerLevelChangeHistory = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.history_visibility"] as! Int? {
+                        return powerLevel
+                    }
+                    return 100
+                }()
+                self.initialPowerLevelChangeTopic = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.topic"] as! Int? {
+                        return powerLevel
+                    }
+                    return powerLevels.stateDefault
+                }()
+                self.initialPowerLevelChangeWidgets = { () -> Int in
+                    if let powerLevel = powerLevels.events["im.vector.modular.widgets"] as! Int? {
+                        return powerLevel
+                    }
+                    return powerLevels.stateDefault
+                }()
+                self.initialPowerLevelChangePowerLevels = { () -> Int in
+                    if let powerLevel = powerLevels.events["m.room.power_levels"] as! Int? {
+                        return powerLevel
+                    }
+                    return 100
+                }()
+
+                self.PowerLevelDefault.integerValue = self.initialPowerLevelDefault!
+                self.PowerLevelSendMessage.integerValue = self.initialPowerLevelSendMessage!
+                self.PowerLevelInvite.integerValue = self.initialPowerLevelInvite!
+                self.PowerLevelKick.integerValue = self.initialPowerLevelKick!
+                self.PowerLevelBan.integerValue = self.initialPowerLevelBan!
+                self.PowerLevelRedactOther.integerValue = self.initialPowerLevelRedactOther!
+                self.PowerLevelChangeName.integerValue = self.initialPowerLevelChangeName!
+                self.PowerLevelChangeAvatar.integerValue = self.initialPowerLevelChangeAvatar!
+                self.PowerLevelChangeCanonicalAlias.integerValue = self.initialPowerLevelChangeCanonicalAlias!
+                self.PowerLevelChangeHistory.integerValue = self.initialPowerLevelChangeHistory!
+                self.PowerLevelChangeTopic.integerValue = self.initialPowerLevelChangeTopic!
+                self.PowerLevelChangeWidgets.integerValue = self.initialPowerLevelChangeWidgets!
+                self.PowerLevelChangePowerLevels.integerValue = self.initialPowerLevelChangePowerLevels!
+                // PowerLevelNotifyAll.integerValue = initialPowerLevelNotifyAll
+                // PowerLevelChangeJoinRule.integerValue = initialPowerLevelChangeJoinRule
+
+                for control in controls {
+                   // control.isEnabled = initialPowerLevelChangePowerLevels! <= powerLevels.powerLevelOfUser(withUserID: MatrixServices.inst.session.myUser.userId)
+                    control.isEnabled = false
                 }
-                return room.state.powerLevels.stateDefault
-            }()
-            initialPowerLevelChangeAvatar = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.avatar"] as! Int? {
-                    return powerLevel
-                }
-                return room.state.powerLevels.stateDefault
-            }()
-            initialPowerLevelChangeCanonicalAlias = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.canonical_alias"] as! Int? {
-                    return powerLevel
-                }
-                return room.state.powerLevels.stateDefault
-            }()
-            initialPowerLevelChangeHistory = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.history_visibility"] as! Int? {
-                    return powerLevel
-                }
-                return 100
-            }()
-            initialPowerLevelChangeTopic = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.topic"] as! Int? {
-                    return powerLevel
-                }
-                return room.state.powerLevels.stateDefault
-            }()
-            initialPowerLevelChangeWidgets = { () -> Int in
-                if let powerLevel = powerLevels.events["im.vector.modular.widgets"] as! Int? {
-                    return powerLevel
-                }
-                return room.state.powerLevels.stateDefault
-            }()
-            initialPowerLevelChangePowerLevels = { () -> Int in
-                if let powerLevel = powerLevels.events["m.room.power_levels"] as! Int? {
-                    return powerLevel
-                }
-                return 100
-            }()
-            
-            PowerLevelDefault.integerValue = initialPowerLevelDefault!
-            PowerLevelSendMessage.integerValue = initialPowerLevelSendMessage!
-            PowerLevelInvite.integerValue = initialPowerLevelInvite!
-            PowerLevelKick.integerValue = initialPowerLevelKick!
-            PowerLevelBan.integerValue = initialPowerLevelBan!
-            PowerLevelRedactOther.integerValue = initialPowerLevelRedactOther!
-            PowerLevelChangeName.integerValue = initialPowerLevelChangeName!
-            PowerLevelChangeAvatar.integerValue = initialPowerLevelChangeAvatar!
-            PowerLevelChangeCanonicalAlias.integerValue = initialPowerLevelChangeCanonicalAlias!
-            PowerLevelChangeHistory.integerValue = initialPowerLevelChangeHistory!
-            PowerLevelChangeTopic.integerValue = initialPowerLevelChangeTopic!
-            PowerLevelChangeWidgets.integerValue = initialPowerLevelChangeWidgets!
-            PowerLevelChangePowerLevels.integerValue = initialPowerLevelChangePowerLevels!
-            // PowerLevelNotifyAll.integerValue = initialPowerLevelNotifyAll
-            // PowerLevelChangeJoinRule.integerValue = initialPowerLevelChangeJoinRule
-            
-            for control in controls {
-               // control.isEnabled = initialPowerLevelChangePowerLevels! <= powerLevels.powerLevelOfUser(withUserID: MatrixServices.inst.session.myUser.userId)
-                control.isEnabled = false
             }
         }
     }

--- a/Seaglass/Model/MatrixServices.swift
+++ b/Seaglass/Model/MatrixServices.swift
@@ -210,10 +210,13 @@ class MatrixServices: NSObject {
                             
                             MatrixServices.inst.session.peek(inRoom: event.roomId, completion: { (response) in
                                 guard !response.isFailure else { return }
-                                
-                                room.liveTimeline.resetPagination()
-                                room.liveTimeline.paginate(100, direction: .backwards, onlyFromStore: false) { _ in
-                                    // complete?
+
+                                room.liveTimeline { liveTimeline in
+                                    guard let liveTimeline = liveTimeline else { fatalError() }
+                                    liveTimeline.resetPagination()
+                                    liveTimeline.paginate(100, direction: .backwards, onlyFromStore: false) { _ in
+                                        // complete?
+                                    }
                                 }
                             })
                         }
@@ -328,87 +331,90 @@ class MatrixServices: NSObject {
             roomCaches[roomId] = MatrixRoomCache()
         }
 
-        if room.state.isEncrypted {
-            session.crypto.downloadKeys(room.state.members.compactMap { return $0.userId }, forceDownload: false, success: { (devicemap) in
-                self.mainController?.channelDelegate?.uiRoomNeedsCryptoReload()
-            }) { (error) in
-                print("Failed to download keys for \(roomId): \(error!.localizedDescription)")
+        room.state { state in
+            if state?.isEncrypted ?? false {
+                self.session.crypto.downloadKeys(state!.members.members.compactMap { return $0.userId }, forceDownload: false, success: { (devicemap) in
+                    self.mainController?.channelDelegate?.uiRoomNeedsCryptoReload()
+                }) { (error) in
+                    print("Failed to download keys for \(roomId): \(error!.localizedDescription)")
+                }
             }
         }
- 
-        eventListeners[roomId] = room.liveTimeline.listenToEvents() { (event, direction, roomState) in
-            guard event.roomId != nil && event.roomId != "" else { return }
-            guard self.mainController?.channelDelegate?.roomId == event.roomId else { return }
-            
-            if event.decryptionError != nil {
-                NotificationCenter.default.addObserver(MatrixServices.inst, selector: #selector(self.eventDidDecrypt), name: NSNotification.Name.mxEventDidDecrypt, object: event)
-            }
 
-            switch event.type {
-            case "m.room.redaction":
-                for e in self.roomCaches[roomId]!.unfilteredContent.filter({ $0.eventId == event.redacts }) {
-                    guard !e.isRedactedEvent() else { continue }
-                    if let index = self.roomCaches[roomId]!.unfilteredContent.firstIndex(where: { $0.eventId == event.redacts }) {
-                        let pruned = e.prune()!
-                        self.roomCaches[roomId]!.replace(pruned, at: index)
-                        self.mainController?.channelDelegate?.matrixDidRoomMessage(event: pruned, direction: direction, roomState: roomState)
-                    }
+        room.liveTimeline { liveTimeline in
+            guard let liveTimeline = liveTimeline else { fatalError() }
+
+            self.eventListeners[roomId] = liveTimeline.listenToEvents() { (event, direction, roomState) in
+                guard event.roomId != nil && event.roomId != "" else { return }
+                guard self.mainController?.channelDelegate?.roomId == event.roomId else { return }
+
+                if event.decryptionError != nil {
+                    NotificationCenter.default.addObserver(MatrixServices.inst, selector: #selector(self.eventDidDecrypt), name: NSNotification.Name.mxEventDidDecrypt, object: event)
                 }
-                break
-            case "m.room.member":
-                if direction == .forwards {
-                    let new = event.content.keys.contains("membership") ? event.content["membership"] as! String : "join"
-                    var old = new == "join" ? "leave" : "join"
-                    if event.prevContent != nil {
-                        old = event.prevContent.keys.contains("membership") ? event.prevContent["membership"] as! String : new == "join" ? "leave" : "join"
+
+                switch event.type {
+                case "m.room.redaction":
+                    for e in self.roomCaches[roomId]!.unfilteredContent.filter({ $0.eventId == event.redacts }) {
+                        guard !e.isRedactedEvent() else { continue }
+                        if let index = self.roomCaches[roomId]!.unfilteredContent.firstIndex(where: { $0.eventId == event.redacts }) {
+                            let pruned = e.prune()!
+                            self.roomCaches[roomId]!.replace(pruned, at: index)
+                            self.mainController?.channelDelegate?.matrixDidRoomMessage(event: pruned, direction: direction, roomState: roomState)
+                        }
                     }
-                    
-                    if new == "leave" && old != "leave" {
-                        self.mainController?.channelDelegate?.matrixDidRoomUserPart(event: event)
-                    } else if new == "join" && old != "join" {
-                        self.mainController?.channelDelegate?.matrixDidRoomUserJoin(event: event)
-                    }
-                }
-                fallthrough
-            default:
-                if !self.roomCaches[roomId]!.unfilteredContent.contains(where: { $0.eventId == event.eventId }) {
+                    break
+                case "m.room.member":
                     if direction == .forwards {
-                        self.roomCaches[roomId]!.append(event)
+                        let new = event.content.keys.contains("membership") ? event.content["membership"] as! String : "join"
+                        var old = new == "join" ? "leave" : "join"
+                        if event.prevContent != nil {
+                            old = event.prevContent.keys.contains("membership") ? event.prevContent["membership"] as! String : new == "join" ? "leave" : "join"
+                        }
+
+                        if new == "leave" && old != "leave" {
+                            self.mainController?.channelDelegate?.matrixDidRoomUserPart(event: event)
+                        } else if new == "join" && old != "join" {
+                            self.mainController?.channelDelegate?.matrixDidRoomUserJoin(event: event)
+                        }
+                    }
+                    fallthrough
+                default:
+                    if !self.roomCaches[roomId]!.unfilteredContent.contains(where: { $0.eventId == event.eventId }) {
+                        if direction == .forwards {
+                            self.roomCaches[roomId]!.append(event)
+                        } else {
+                            self.roomCaches[roomId]!.insert(event, at: 0)
+                        }
                     } else {
-                        self.roomCaches[roomId]!.insert(event, at: 0)
+                        if let index = self.roomCaches[roomId]!.unfilteredContent.firstIndex(where: { $0.eventId == event.eventId }) {
+                            self.roomCaches[roomId]!.replace(event, at: index)
+                        }
                     }
-                } else {
-                    if let index = self.roomCaches[roomId]!.unfilteredContent.firstIndex(where: { $0.eventId == event.eventId }) {
-                        self.roomCaches[roomId]!.replace(event, at: index)
-                    }
+                    self.mainController?.channelDelegate?.matrixDidRoomMessage(event: event, direction: direction, roomState: roomState);
+                    self.mainController?.roomsDelegate?.matrixDidUpdateRoom(room)
+                    break
                 }
-                self.mainController?.channelDelegate?.matrixDidRoomMessage(event: event, direction: direction, roomState: roomState);
-                self.mainController?.roomsDelegate?.matrixDidUpdateRoom(room)
-                break
-            }
-        } as? MXEventListener
+            } as? MXEventListener
+        }
+
     }
     
-    func userHasPower(inRoomId: String, forEvent: String) -> Bool {
-        let room = session.room(withRoomId: inRoomId)
-        if room == nil {
-            return false
-        }
-        if room!.state.powerLevels == nil {
+    func userHasPower(inRoomId: String, forEvent: String, withRoomState state: MXRoomState) -> Bool {
+        guard let powerLevels = state.powerLevels else {
             return false
         }
         if session.invitedRooms().contains(where: { $0.roomId == inRoomId }) {
             return false
         }
         let powerLevel = { () -> Int in
-            if room!.state.powerLevels.events.count == 0 {
-                return room!.state.powerLevels.stateDefault
+            if powerLevels.events.count == 0 {
+                return powerLevels.stateDefault
             }
-            if room!.state.powerLevels.events.contains(where: { (arg) -> Bool in arg.key as? String == forEvent }) {
-                return room!.state.powerLevels.events[forEvent] as! Int
+            if powerLevels.events.contains(where: { (arg) -> Bool in arg.key as? String == forEvent }) {
+                return powerLevels.events[forEvent] as! Int
             }
-            return room!.state.powerLevels.stateDefault
+            return powerLevels.stateDefault
         }()
-        return room!.state.powerLevels.powerLevelOfUser(withUserID: session.myUser.userId) >= powerLevel
+        return powerLevels.powerLevelOfUser(withUserID: session.myUser.userId) >= powerLevel
     }
 }

--- a/Seaglass/Subclass/Member Lists/MembersCacheEntry.swift
+++ b/Seaglass/Subclass/Member Lists/MembersCacheEntry.swift
@@ -21,12 +21,14 @@ import SwiftMatrixSDK
 
 class MembersCacheEntry: NSObject {
     var member: MXRoomMember
+    var state: MXRoomState
     
     @objc dynamic var displayName: String
     @objc dynamic var userId: String
     
-    init(_ member: MXRoomMember) {
+    init(_ member: MXRoomMember, state: MXRoomState) {
         self.member = member
+        self.state = state
         
         userId = member.userId
         displayName = member.displayname ?? ""

--- a/Seaglass/Subclass/Room Lists/RoomsCacheEntry.swift
+++ b/Seaglass/Subclass/Room Lists/RoomsCacheEntry.swift
@@ -21,21 +21,22 @@ import SwiftMatrixSDK
 
 class RoomsCacheEntry: NSObject {
     var room: MXRoom
+    var state: MXRoomState
     
     @objc dynamic var roomId: String {
         return room.roomId
     }
     @objc dynamic var roomName: String {
-        return room.state.name ?? ""
+        return state.name ?? ""
     }
     @objc dynamic var roomAlias: String {
-        return room.state.canonicalAlias ?? ""
+        return state.canonicalAlias ?? ""
     }
     @objc dynamic var roomTopic: String  {
-        return room.state.topic ?? ""
+        return state.topic ?? ""
     }
     @objc dynamic var roomAvatar: String {
-        return room.state.avatar ?? ""
+        return state.avatar ?? ""
     }
     @objc dynamic var roomSortWeight: Int {
         if isInvite() {
@@ -44,11 +45,11 @@ class RoomsCacheEntry: NSObject {
         if room.isDirect {
             return 70
         }
-        if room.summary.isEncrypted || room.state.isEncrypted {
+        if room.summary.isEncrypted || state.isEncrypted {
             return 60
         }
-        if room.state.name == "" {
-            if room.state.topic == "" {
+        if state.name == "" {
+            if state.topic == "" {
                 return 52
             }
             return 51
@@ -77,16 +78,17 @@ class RoomsCacheEntry: NSObject {
         return ""
     }
     var members: [MXRoomMember] {
-        return room.state.members
+        return state.members.members ?? []
     }
     
-    init(_ room: MXRoom) {
+    init(room: MXRoom, state: MXRoomState) {
         self.room = room
+        self.state = state
         super.init()
     }
     
     func topic() -> String {
-        return room.state.topic
+        return state.topic
     }
     
     func unread() -> Bool {
@@ -109,7 +111,7 @@ class RoomsCacheEntry: NSObject {
     }
     
     func encrypted() -> Bool {
-        return room.summary.isEncrypted || room.state.isEncrypted
+        return room.summary.isEncrypted || state.isEncrypted
     }
     
     func isInvite() -> Bool {

--- a/Seaglass/Subclass/Room Message Types/RoomMessage.swift
+++ b/Seaglass/Subclass/Room Message Types/RoomMessage.swift
@@ -89,8 +89,13 @@ class RoomMessage: NSTableCellView {
         if event == nil {
             return ""
         }
+        var name: String?
         if let room = MatrixServices.inst.session.room(withRoomId: event!.roomId) {
-            return room.state.memberName(event!.sender) ?? event!.sender as String
+            room.state { state in
+                let sender = self.event!.sender
+                name = state?.members.memberName(sender) ?? sender
+            }
+            return name ?? ""
         }
         return ""
     }

--- a/Seaglass/Subclass/Room Message Types/RoomMessageIncoming.swift
+++ b/Seaglass/Subclass/Room Message Types/RoomMessageIncoming.swift
@@ -51,11 +51,14 @@ class RoomMessageIncoming: RoomMessage {
         Time.stringValue = super.timestamp()
         Time.toolTip = super.timestamp(.medium, andDate: .medium)
         Avatar.setAvatar(forUserId: event!.sender)
-        
-        let icon = super.icon()
-        Icon.isHidden = !room.state.isEncrypted
-        Icon.image = icon.image
-        Icon.setFrameSize(room.state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+
+        room.state { state in
+            guard let state = state else { fatalError() }
+            let icon = super.icon()
+            self.Icon.isHidden = !state.isEncrypted
+            self.Icon.image = icon.image
+            self.Icon.setFrameSize(state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+        }
         
         var finalTextColor = NSColor.textColor
         let displayname = MatrixServices.inst.session.myUser.displayname ?? MatrixServices.inst.session.myUser.userId
@@ -172,11 +175,14 @@ class RoomMessageIncoming: RoomMessage {
         Icon.event = event!
         switch event!.sentState {
         case MXEventSentStateFailed:
-            if !room!.state.isEncrypted {
-                Icon.isHidden = false
-                Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+            room?.state { state in
+                guard let state = state else { fatalError() }
+                if !state.isEncrypted {
+                    self.Icon.isHidden = false
+                    self.Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+                }
+                self.Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             }
-            Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             break
         default:
             break

--- a/Seaglass/Subclass/Room Message Types/RoomMessageIncomingCoalesced.swift
+++ b/Seaglass/Subclass/Room Message Types/RoomMessageIncomingCoalesced.swift
@@ -46,9 +46,11 @@ class RoomMessageIncomingCoalesced: RoomMessage {
         Time.toolTip = super.timestamp(.medium, andDate: .medium)
         
         let icon = super.icon()
-        Icon.isHidden = !room.state.isEncrypted
-        Icon.image = icon.image
-        Icon.setFrameSize(room.state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+        room.state { state in
+            self.Icon.isHidden = !state!.isEncrypted
+            self.Icon.image = icon.image
+            self.Icon.setFrameSize(state!.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+        }
         
         var finalTextColor = NSColor.textColor
         let displayname = MatrixServices.inst.session.myUser.displayname ?? MatrixServices.inst.session.myUser.userId
@@ -165,11 +167,13 @@ class RoomMessageIncomingCoalesced: RoomMessage {
         Icon.event = event!
         switch event!.sentState {
         case MXEventSentStateFailed:
-            if !room!.state.isEncrypted {
-                Icon.isHidden = false
-                Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+            room!.state { state in
+                if !state!.isEncrypted {
+                    self.Icon.isHidden = false
+                    self.Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+                }
+                self.Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             }
-            Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             break
         default:
             break

--- a/Seaglass/Subclass/Room Message Types/RoomMessageOutgoing.swift
+++ b/Seaglass/Subclass/Room Message Types/RoomMessageOutgoing.swift
@@ -51,11 +51,14 @@ class RoomMessageOutgoing: RoomMessage {
         Time.stringValue = super.timestamp()
         Time.toolTip = super.timestamp(.medium, andDate: .medium)
         Avatar.setAvatar(forUserId: event!.sender)
-        
-        let icon = super.icon()
-        Icon.isHidden = !room.state.isEncrypted
-        Icon.image = icon.image
-        Icon.setFrameSize(room.state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+
+        room.state { state in
+            guard let state = state else { fatalError() }
+            let icon = super.icon()
+            self.Icon.isHidden = !state.isEncrypted
+            self.Icon.image = icon.image
+            self.Icon.setFrameSize(state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+        }
         
         var finalTextColor = NSColor.textColor
         
@@ -169,9 +172,13 @@ class RoomMessageOutgoing: RoomMessage {
         Icon.event = event!
         switch event!.sentState {
         case MXEventSentStateFailed:
-            if !room!.state.isEncrypted {
-                Icon.isHidden = false
-                Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+            room!.state { state in
+                if !state!.isEncrypted {
+                    self.Icon.isHidden = false
+                    self.Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+                }
+                self.Icon.isHidden = false
+                self.Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
             }
             Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             break

--- a/Seaglass/Subclass/Room Message Types/RoomMessageOutgoingCoalesced.swift
+++ b/Seaglass/Subclass/Room Message Types/RoomMessageOutgoingCoalesced.swift
@@ -44,11 +44,15 @@ class RoomMessageOutgoingCoalesced: RoomMessage {
         
         Time.stringValue = super.timestamp()
         Time.toolTip = super.timestamp(.medium, andDate: .medium)
-        
-        let icon = super.icon()
-        Icon.isHidden = !room.state.isEncrypted
-        Icon.image = icon.image
-        Icon.setFrameSize(room.state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+
+        room.state { state in
+            guard let state = state else { fatalError() }
+
+            let icon = super.icon()
+            self.Icon.isHidden = !state.isEncrypted
+            self.Icon.image = icon.image
+            self.Icon.setFrameSize(state.isEncrypted ? NSMakeSize(icon.width, icon.height) : NSMakeSize(0, icon.height))
+        }
         
         var finalTextColor = NSColor.textColor
         
@@ -159,11 +163,13 @@ class RoomMessageOutgoingCoalesced: RoomMessage {
         Icon.event = event!
         switch event!.sentState {
         case MXEventSentStateFailed:
-            if !room!.state.isEncrypted {
-                Icon.isHidden = false
-                Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+            room?.state { state in
+                if !state!.isEncrypted {
+                    self.Icon.isHidden = false
+                    self.Icon.setFrameSize(NSMakeSize(icon.width, icon.height))
+                }
+                self.Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             }
-            Icon.image = NSImage(named: NSImage.refreshTemplateName)!.tint(with: NSColor.red)
             break
         default:
             break


### PR DESCRIPTION
I popped into the chat a couple weeks and mentioned I wanted to help a little. Brining the MatrixSDK up to date was one of the tasks mentioned. This change doesn't bring it completely up to date but it's a step closer.

---

The SwiftMatrixSDK developers have documented all the breaking changes between v0.10 and v0.11 of SwiftMatrixSDK in the release notes for v0.11.0. Those notes are available on GitHub at the following address <https://github.com/matrix-org/matrix-ios-sdk/releases/tag/v0.11.0>

Only two of them appear to impact Seaglass, so I'm summarizing those here:

1) MXRoom: liveTimeline and state accesses are now asynchronous.

Most of the changes to support this involved wrapping the code that accessed the async property in a closure. There were a few places that required further rework, like adding state as an initialize to an object or a parameter to a method so they could be available when the method returned.

2) MXRoomState: Create an MXRoomMembers property. All members getter methods has been to the new class.

The MXRoomState changes to the member class required adding an extra `.members` in a few places to get access to the `members` array that used to be directly on `MXRoomState` but is not in the `MXRoomMembers` property on `MXRoomState`.