### PR TITLE
Add workaround for broken install to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,15 @@ in auto updating feature to ensure you have the latest version.
 brew cask install seaglass
 ```
 
+There is a known issue where you may have to clear attributes after installing.
+https://github.com/neilalexander/seaglass/issues/128
+
+If you get a "Seaglass.app is damaged and can't be opened." window when launching the app clear attributes with the below command and then launch the app again.
+
+```
+xattr -cr /Applications/Seaglass.app
+```
+
 ## Building from source
 
 Use Xcode 9.4 or Xcode 10.0 on macOS 10.13. Seaglass may require macOS 10.13 as a


### PR DESCRIPTION
* Out of the box brew install fails to start with "Seaglass is damaged and can't be opened. You should move it to the Trash".
* Removing attributes fixes this from issue: https://github.com/neilalexander/seaglass/issues/128
* Add the fix to the README for new users until a real fix is in place.