### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or you can install Seaglass from Homebrew Cask. Either way, you'll be able to us
 in auto updating feature to ensure you have the latest version.
 
 ```
-brew cask install seaglass
+brew install --cask seaglass
 ```
 
 ## Building from source


### PR DESCRIPTION
When installing via brew cask install seaglass, It shows this warning message : Calling brew cask install is deprecated! Use brew install [--cask] instead.

The change was announced in homebrew v2.5.0: https://brew.sh/2020/09/08/homebrew-2.5.0/