### PR TITLE
Update brew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ or you can install Seaglass from Homebrew Cask. Either way, you'll be able to us
 in auto updating feature to ensure you have the latest version.
 
 ```
-brew cask install seaglass
+brew install seaglass
 ```
 
 ## Building from source


### PR DESCRIPTION
`brew cask` is no longer needed, and gives an error on current Homebrew if tried. I was able to install the app via `brew install seaglass`